### PR TITLE
Update templates to match helm best practices

### DIFF
--- a/chart/postgres-operator/templates/_helpers.tpl
+++ b/chart/postgres-operator/templates/_helpers.tpl
@@ -2,33 +2,49 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "postgres-operator.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
+{{- define "postgres-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "postgres-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "serviceAccountName" -}}
+{{- define "postgres-operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{- (include "fullname" .) -}}
+    {{ default (include "postgres-operator.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
-    {{ "default" }}
+    {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Create the name of the namespace role to use
 */}}
-{{- define "namespaceRoleName" -}}
-{{- printf "%s-%s" (include "fullname" .) .Release.Namespace -}}
+{{- define "postgres-operator.namespaceRoleName" -}}
+{{- printf "%s-%s" (include "postgres-operator.fullname" .) .Release.Namespace -}}
 {{- end -}}

--- a/chart/postgres-operator/templates/apiserver-config-map.yaml
+++ b/chart/postgres-operator/templates/apiserver-config-map.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}-apiserver
+  name: {{ template "postgres-operator.fullname" . }}-apiserver
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 type: Opaque

--- a/chart/postgres-operator/templates/cluster-role-binding.yaml
+++ b/chart/postgres-operator/templates/cluster-role-binding.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "postgres-operator.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "postgres-operator.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "serviceAccountName" . }}
+  name: {{ template "postgres-operator.serviceAccountName" . }}
   namespace: "{{ .Release.Namespace }}"
 {{ end }}

--- a/chart/postgres-operator/templates/cluster-role.yaml
+++ b/chart/postgres-operator/templates/cluster-role.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "postgres-operator.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 rules:
   - verbs:
       - get

--- a/chart/postgres-operator/templates/configmap.yaml
+++ b/chart/postgres-operator/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-operator
+  name: {{ template "postgres-operator.fullname" . }}-operator
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:

--- a/chart/postgres-operator/templates/deployment.yaml
+++ b/chart/postgres-operator/templates/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "postgres-operator.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -12,12 +12,11 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "postgres-operator.name" . }}
         release: {{ .Release.Name }}
-        name: postgres-operator
     spec:
       containers:
-        - name: apiserver
+        - name: {{ .Chart.Name }}-apiserver
           image: "{{ .Values.env.co_image_prefix }}/pgo-apiserver:{{ .Values.env.co_image_tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext: {}
@@ -37,7 +36,7 @@ spec:
             - name: operator-conf
               mountPath: /operator-conf
               readOnly: true
-        - name: operator
+        - name: {{ .Chart.Name }}-operator
           image: "{{ .Values.env.co_image_prefix }}/postgres-operator:{{ .Values.env.co_image_tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext: {}
@@ -67,7 +66,7 @@ spec:
       volumes:
         - name: operator-conf
           configMap:
-            name: {{ template "fullname" . }}-operator
+            name: {{ template "postgres-operator.fullname" . }}-operator
         - name: apiserver-conf
           secret:
-            secretName: {{ template "fullname" . }}-apiserver
+            secretName: {{ template "postgres-operator.fullname" . }}-apiserver

--- a/chart/postgres-operator/templates/role-binding.yaml
+++ b/chart/postgres-operator/templates/role-binding.yaml
@@ -2,19 +2,19 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: {{ template "namespaceRoleName" . }}
+  name: {{ template "postgres-operator.namespaceRoleName" . }}
   namespace: "{{ .Release.Namespace }}"
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "namespaceRoleName" . }}
+  name: {{ template "postgres-operator.namespaceRoleName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "serviceAccountName" . }}
+  name: {{ template "postgres-operator.serviceAccountName" . }}
   namespace: "{{ .Release.Namespace }}"
 {{ end }}

--- a/chart/postgres-operator/templates/role.yaml
+++ b/chart/postgres-operator/templates/role.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: {{ template "namespaceRoleName" . }}
+  name: {{ template "postgres-operator.namespaceRoleName" . }}
   namespace: "{{ .Release.Namespace }}"
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 rules:
   - verbs:
       - '*'

--- a/chart/postgres-operator/templates/service-account.yaml
+++ b/chart/postgres-operator/templates/service-account.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "serviceAccountName" . }}
+  name: {{ template "postgres-operator.serviceAccountName" . }}
   labels:
-    app: "{{ template "name" . }}"
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   namespace: "{{ .Release.Namespace }}"
 {{ end }}

--- a/chart/postgres-operator/templates/service.yaml
+++ b/chart/postgres-operator/templates/service.yaml
@@ -1,20 +1,21 @@
+
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ template "postgres-operator.fullname" . }}
   labels:
-    app: "{{ template "name" . }}"
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  name: {{ template "fullname" . }}
+    app: {{ template "postgres-operator.name" . }}
+    chart: {{ template "postgres-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
-  type: "ClusterIP"
+  type: {{ .Values.service.type }}
   ports:
-    - name: apiserver
-      port: 8443
-      protocol: TCP
+    - port: {{ .Values.service.port }}
       targetPort: 8443
+      protocol: TCP
+      name: apiserver
       nodePort: 0
   selector:
-    name: postgres-operator
+    app: {{ template "postgres-operator.name" . }}
     release: {{ .Release.Name }}

--- a/chart/postgres-operator/values.yaml
+++ b/chart/postgres-operator/values.yaml
@@ -14,6 +14,10 @@ env:
   co_image_prefix: "crunchydata"
   co_image_tag: "centos7-3.0"
 
+service:
+  type: ClusterIP
+  port: 8443
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
Some tweaks for your pr [#228](https://github.com/CrunchyData/postgres-operator/pull/228) based on the tips in the following links, and on the default service scaffolding helm provides.
https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices
https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/templates.md\#names-of-defined-templates
https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/rbac.md\#using-rbac-resources